### PR TITLE
move sliceOne logic into ByteBuffersDataInput level

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -170,7 +170,6 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
       final int len = (int) (buffersInput.size() - buffersInput.position());
-      final int end = (int) buffersInput.size();
       final int dictLength = len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR);
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
       buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);
@@ -183,7 +182,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       doCompress(buffer, 0, dictLength, out);
 
       // And then sub blocks
-      for (int start = dictLength; start < end; start += blockLength) {
+      for (int start = dictLength; start < len; start += blockLength) {
         int l = Math.min(blockLength, len - start);
         buffersInput.readBytes(buffer, dictLength, l);
         doCompress(buffer, dictLength, l, out);

--- a/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.store;
 
-import java.nio.ByteBuffer;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
@@ -172,9 +171,5 @@ public final class ByteArrayDataInput extends DataInput {
   public void readBytes(byte[] b, int offset, int len) {
     System.arraycopy(bytes, pos, b, offset, len);
     pos += len;
-  }
-
-  public ByteBuffer toByteBuffer(int length) {
-    return ByteBuffer.wrap(bytes, pos, length).asReadOnlyBuffer();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -229,13 +229,6 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
     }
   }
 
-  public void copyBytes(ByteArrayDataInput input, long numBytes) throws IOException {
-    assert numBytes >= 0;
-    int l = Math.min(input.length() - input.getPosition(), (int) numBytes);
-    ByteBuffer bb = input.toByteBuffer(l);
-    writeBytes(bb);
-  }
-
   /**
    * Return a list of read-only view of {@link ByteBuffer} blocks over the current content written
    * to the output.


### PR DESCRIPTION
1. change statement byteBuffers in Lucene90CompressingStoredFieldsWriter
2. move sliceOne logic into ByteBuffersDataInput level
3. delete copyOneDoc instance ByteArrayDataInput optimize for separate change
4. delete DeflateWithPresetDictCompressionMode#doCompress with param byte[] instead of bytebuffer

